### PR TITLE
[main] pdx203: Override fstab suffix

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -27,7 +27,9 @@ endif
 # Platform
 PRODUCT_PLATFORM := edo
 
+# Kernel cmdline
 BOARD_KERNEL_CMDLINE += androidboot.hardware=pdx203
+BOARD_KERNEL_CMDLINE += androidboot.fstab_suffix=pdx203
 
 # Partition information
 BOARD_FLASH_BLOCK_SIZE := 131072 # (BOARD_KERNEL_PAGESIZE * 64)


### PR DESCRIPTION
The default suffix of stock 11 bootloader is androidboot.fstab_suffix=default, so fix it

Detail: https://github.com/sonyxperiadev/device-sony-pdx201/pull/24