### PR TITLE
[u-mr1] AndroidProducts: Set release configuration to AP2A

### DIFF
--- a/AndroidProducts.mk
+++ b/AndroidProducts.mk
@@ -16,7 +16,7 @@ PRODUCT_MAKEFILES := $(LOCAL_DIR)/aosp_xqat51.mk \
                      $(LOCAL_DIR)/aosp_xqat52.mk
 
 COMMON_LUNCH_CHOICES += \
-    aosp_xqat51-eng \
-    aosp_xqat51-userdebug \
-    aosp_xqat52-eng \
-    aosp_xqat52-userdebug
+    aosp_xqat51-ap2a-eng \
+    aosp_xqat51-ap2a-userdebug \
+    aosp_xqat52-ap2a-eng \
+    aosp_xqat52-ap2a-userdebug


### PR DESCRIPTION
Starting with the latest revisions of Android 14 the string
representing the target has the following format:
product_name-release_config-build_variant.
Most likely we will freeze on the r67 tag which provides
only the AP2A release config[1].

[1] https://android.googlesource.com/platform/build/release/+/refs/tags/android-14.0.0_r67/aconfig